### PR TITLE
ci(codecov): Setup Codecov info using Codecov CLI

### DIFF
--- a/.github/workflows/codecov_ats.yml
+++ b/.github/workflows/codecov_ats.yml
@@ -1,0 +1,109 @@
+name: Codecov ATS test
+
+on:
+  push:
+
+env:
+  CLI_VERSION: v0.1.5
+
+# Cancel in progress workflows on pull_requests.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  codecov-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10.10"
+      - name: Download Codecov CLI
+        run: |
+          pip install pytest codecov-cli
+      - name: Save commit info
+        run: |
+          codecovcli create-commit --git-service=github --token=${{ secrets.CODECOV_TOKEN }}
+      - name: Create report
+        run: |
+          codecovcli create-report --git-service=github --token=${{ secrets.CODECOV_TOKEN }}
+  static-analysis:
+    needs: codecov-report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10.10"
+      - name: Download Codecov CLI
+        run: |
+          pip install pytest codecov-cli
+      - name: Run Static Analysis
+        run: |
+          codecovcli static-analysis --token=${{ secrets.STATIC_TOKEN }} \
+          --folders-to-exclude .artifacts \
+          --folders-to-exclude .github \
+          --folders-to-exclude .venv \
+          --folders-to-exclude static \
+          --folders-to-exclude bin
+  # files-changed:
+  #   name: detect what files changed
+  #   runs-on: ubuntu-20.04
+  #   timeout-minutes: 3
+  #   # Map a step output to a job output
+  #   outputs:
+  #     api_docs: ${{ steps.changes.outputs.api_docs }}
+  #     backend: ${{ steps.changes.outputs.backend_all }}
+  #     backend_dependencies: ${{ steps.changes.outputs.backend_dependencies }}
+  #     backend_any_type: ${{ steps.changes.outputs.backend_any_type }}
+  #     migration_lockfile: ${{ steps.changes.outputs.migration_lockfile }}
+  #     plugins: ${{ steps.changes.outputs.plugins }}
+  #   steps:
+  #     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
+
+  #     - name: Check for backend file changes
+  #       uses: getsentry/paths-filter@4512585405083f25c027a35db413c2b3b9006d50  # v2.11.1
+  #       id: changes
+  #       with:
+  #         token: ${{ github.token }}
+  #         filters: .github/file-filters.yml
+  # label-analysis:
+  #   # if: needs.files-changed.outputs.backend == 'true'
+  #   needs: [static-analysis, files-changed]
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
+  #     # and reducing the risk that one of many runs would turn red again (read: intermittent tests)
+  #     fail-fast: false
+  #     matrix:
+  #       pg-version: ['14']
+  #   steps:
+  #     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
+  #       with:
+  #         fetch-depth: '2'
+  #     - name: Setup sentry env
+  #       uses: ./.github/actions/setup-sentry
+  #       id: setup
+  #       with:
+  #         snuba: true
+  #         # Right now, we run so few bigtable related tests that the
+  #         # overhead of running bigtable in all backend tests
+  #         # is way smaller than the time it would take to run in its own job.
+  #         bigtable: true
+  #         pg-version: ${{ matrix.pg-version }}
+  #     - name: Download Codecov CLI
+  #       run: |
+  #         pip install --extra-index-url https://pypi.org/simple pytest codecov-cli
+  #     - name: Run backend tests with ATS
+  #       run: |
+  #         BASE_COMMIT=$(git rev-parse HEAD^)
+  #         echo "Using base commit ${BASE_COMMIT}"
+  #         codecovcli -v --codecov-yml-path=codecov.yml label-analysis --token=${{ secrets.STATIC_TOKEN }} --base-sha=${BASE_COMMIT}
+  #     - name: Upload to Codecov
+  #       run: |
+  #         coverage json --show-contexts -o .artifacts/label.coverage.json
+  #         rm .coverage
+  #         codecovcli --verbose do-upload --flag smart-backend --file=.artifacts/label.coverage.json --token=${{ secrets.CODECOV_TOKEN }}  --fail-on-error

--- a/codecov.yml
+++ b/codecov.yml
@@ -45,6 +45,25 @@ component_management:
         paths:
           - "src/sentry/static/sentry/app/utils/profiling/**"
 
+beta_groups:
+  - "labels"
+
+flag_management:
+  individual_flags:
+    - name: smart-backend
+      carryforward: true
+      carryforward_mode: "labels"
+      statuses:
+        - type: "patch"
+          only_pulls: true # This is only for PRs
+          informational: false # Fail the check
+          target: 90%
+        - type: "patch"
+          branches:  # This is only for master
+            - master
+          informational: true # Don't fail ever
+          target: 90%
+
 flags:
   frontend:
     paths:
@@ -74,3 +93,18 @@ comment:
   require_changes: true
   require_base: yes # must have a base report to post
   require_head: yes # must have a head report to post
+
+
+cli:
+  runners:
+    python:
+      include_curr_dir: true
+      collect_tests_options:
+        - "tests/integration"
+        - "tests/sentry"
+        - "--ignore=tests/sentry/eventstream/kafka"
+        - "--ignore=tests/sentry/post_process_forwarder"
+        - "--ignore=tests/sentry/snuba"
+        - "--ignore=tests/sentry/search/events"
+        - "--ignore=tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py"
+        - "--ignore=tests/sentry/region_to_control/test_region_to_control_kafka.py"


### PR DESCRIPTION
These changes introduce a new workflow to enable ATS for backend tests.
This process has multiple steps, detailed below.
1. Setup the CLI
  Downloads the CLI using Pypi when needed.
2. CLI requirements (codecov-report)
  The Codecov CLI has a different architecture than previous uploads.
  It needs a "startup" step - create commit and report.
  This is done in the `codecov-report` job (in `codecov_ats.yml`)
3. Upload Static Analysis info (static-analysis)
  In order for ATS to work Codecov needs info from the code.
  The `static-analysis` job runs the analyser (inside the CLI) and
  uploads that info to Codecov

Steps below are commented out. This is because static-analysis is a requirement to ATS,
and if we try to merge everything together, we'll get an error on the CI.
So these changes will come in a future PR.
4. Run label-analysis (ATS magic)
  The `label-analysis` step, if needed to be run (depending on files-changed)
  executes the label analysis and runs the tests needed to run.
5. Convert coverage to JSON and upload to codecov
  label information is only supported via JSON format (atm)

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
