### PR TITLE
ci(codecov): Enable ATS

### DIFF
--- a/.github/workflows/codecov_ats.yml
+++ b/.github/workflows/codecov_ats.yml
@@ -49,61 +49,61 @@ jobs:
           --folders-to-exclude .venv \
           --folders-to-exclude static \
           --folders-to-exclude bin
-  # files-changed:
-  #   name: detect what files changed
-  #   runs-on: ubuntu-20.04
-  #   timeout-minutes: 3
-  #   # Map a step output to a job output
-  #   outputs:
-  #     api_docs: ${{ steps.changes.outputs.api_docs }}
-  #     backend: ${{ steps.changes.outputs.backend_all }}
-  #     backend_dependencies: ${{ steps.changes.outputs.backend_dependencies }}
-  #     backend_any_type: ${{ steps.changes.outputs.backend_any_type }}
-  #     migration_lockfile: ${{ steps.changes.outputs.migration_lockfile }}
-  #     plugins: ${{ steps.changes.outputs.plugins }}
-  #   steps:
-  #     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
+  files-changed:
+    name: detect what files changed
+    runs-on: ubuntu-20.04
+    timeout-minutes: 3
+    # Map a step output to a job output
+    outputs:
+      api_docs: ${{ steps.changes.outputs.api_docs }}
+      backend: ${{ steps.changes.outputs.backend_all }}
+      backend_dependencies: ${{ steps.changes.outputs.backend_dependencies }}
+      backend_any_type: ${{ steps.changes.outputs.backend_any_type }}
+      migration_lockfile: ${{ steps.changes.outputs.migration_lockfile }}
+      plugins: ${{ steps.changes.outputs.plugins }}
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
 
-  #     - name: Check for backend file changes
-  #       uses: getsentry/paths-filter@4512585405083f25c027a35db413c2b3b9006d50  # v2.11.1
-  #       id: changes
-  #       with:
-  #         token: ${{ github.token }}
-  #         filters: .github/file-filters.yml
-  # label-analysis:
-  #   # if: needs.files-changed.outputs.backend == 'true'
-  #   needs: [static-analysis, files-changed]
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
-  #     # and reducing the risk that one of many runs would turn red again (read: intermittent tests)
-  #     fail-fast: false
-  #     matrix:
-  #       pg-version: ['14']
-  #   steps:
-  #     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
-  #       with:
-  #         fetch-depth: '2'
-  #     - name: Setup sentry env
-  #       uses: ./.github/actions/setup-sentry
-  #       id: setup
-  #       with:
-  #         snuba: true
-  #         # Right now, we run so few bigtable related tests that the
-  #         # overhead of running bigtable in all backend tests
-  #         # is way smaller than the time it would take to run in its own job.
-  #         bigtable: true
-  #         pg-version: ${{ matrix.pg-version }}
-  #     - name: Download Codecov CLI
-  #       run: |
-  #         pip install --extra-index-url https://pypi.org/simple pytest codecov-cli
-  #     - name: Run backend tests with ATS
-  #       run: |
-  #         BASE_COMMIT=$(git rev-parse HEAD^)
-  #         echo "Using base commit ${BASE_COMMIT}"
-  #         codecovcli -v --codecov-yml-path=codecov.yml label-analysis --token=${{ secrets.STATIC_TOKEN }} --base-sha=${BASE_COMMIT}
-  #     - name: Upload to Codecov
-  #       run: |
-  #         coverage json --show-contexts -o .artifacts/label.coverage.json
-  #         rm .coverage
-  #         codecovcli --verbose do-upload --flag smart-backend --file=.artifacts/label.coverage.json --token=${{ secrets.CODECOV_TOKEN }}  --fail-on-error
+      - name: Check for backend file changes
+        uses: getsentry/paths-filter@4512585405083f25c027a35db413c2b3b9006d50  # v2.11.1
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+  label-analysis:
+    if: needs.files-changed.outputs.backend == 'true'
+    needs: [static-analysis, files-changed]
+    runs-on: ubuntu-latest
+    strategy:
+      # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
+      # and reducing the risk that one of many runs would turn red again (read: intermittent tests)
+      fail-fast: false
+      matrix:
+        pg-version: ['14']
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
+        with:
+          fetch-depth: '2'
+      - name: Setup sentry env
+        uses: ./.github/actions/setup-sentry
+        id: setup
+        with:
+          snuba: true
+          # Right now, we run so few bigtable related tests that the
+          # overhead of running bigtable in all backend tests
+          # is way smaller than the time it would take to run in its own job.
+          bigtable: true
+          pg-version: ${{ matrix.pg-version }}
+      - name: Download Codecov CLI
+        run: |
+          pip install --extra-index-url https://pypi.org/simple pytest codecov-cli
+      - name: Run backend tests with ATS
+        run: |
+          BASE_COMMIT=$(git rev-parse HEAD^)
+          echo "Using base commit ${BASE_COMMIT}"
+          codecovcli -v --codecov-yml-path=codecov.yml label-analysis --token=${{ secrets.STATIC_TOKEN }} --base-sha=${BASE_COMMIT}
+      - name: Upload to Codecov
+        run: |
+          coverage json --show-contexts -o .artifacts/label.coverage.json
+          rm .coverage
+          codecovcli --verbose do-upload --flag smart-backend --file=.artifacts/label.coverage.json --token=${{ secrets.CODECOV_TOKEN }}  --fail-on-error


### PR DESCRIPTION
These changes enable ATS to run when backend files are changed. **Expect the first runs to take a long time**

Over time, only the changed tests that codecov has no record of should be run, iteratively reducing the number of tests run.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
