### PR TITLE
Merge branch 'getsentry:master' into master

### DIFF
--- a/.github/workflows/codecov_ats.yml
+++ b/.github/workflows/codecov_ats.yml
@@ -103,12 +103,12 @@ jobs:
           pg-version: ${{ matrix.pg-version }}
       - name: Download Codecov CLI
         run: |
-          pip install --extra-index-url https://pypi.org/simple --no-cache-dir pytest codecov-cli
+          pip install --extra-index-url https://pypi.org/simple --extra-index-url https://test.pypi.org/simple/ --no-cache-dir codecov-cli==0.1.11.post4
       - name: Run backend test with ATS (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
         run: |
           BASE_COMMIT=$(git rev-parse HEAD^)
           echo "Using base commit ${BASE_COMMIT}"
-          codecovcli --codecov-yml-path=codecov_cli.yml label-analysis --token=${{ secrets.STATIC_TOKEN }} --base-sha=${BASE_COMMIT}
+          codecovcli --codecov-yml-path=codecov_cli.yml --verbose label-analysis --token=${{ secrets.STATIC_TOKEN }} --base-sha=${BASE_COMMIT}
       - name: Upload to Codecov
         # Always upload to codecov
         if: ${{ always() }}


### PR DESCRIPTION
TEST WITH CLI TEST RELEASE VERSION 0.1.11.post4 (use subprocess.run not pytest from python)




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
